### PR TITLE
Issue 403 Forbidden

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -142,9 +142,9 @@ class Module extends \yii\base\Module
      */
     public function beforeAction($action)
     {
-        if (!Yii::$app->authManager->isAdmin() && !empty($this->accessFilterBehavior)) {
+        if (!Yii::$app->user->isAdmin() && !empty($this->accessFilterBehavior)) {
             $action->controller->attachBehavior('accessFilter', $this->accessFilterBehavior);
-        } elseif (!Yii::$app->authManager->isAdmin() && !Yii::$app->authManager->checkRoute()) {
+        } elseif (!Yii::$app->user->isAdmin() && !Yii::$app->authManager->checkRoute()) {
             throw new ForbiddenHttpException(Yii::t('yii', 'You are not allowed to perform this action.'));
         }
 


### PR DESCRIPTION
When i enter to the path /auth like admin user i get the 403 forbidden but if i change the method beforeAction() 
$app->authmanager->isAdmin() to $app->user->isAdmin() is working well, i dont know if i'm right doing this propose file change.

Greetings
